### PR TITLE
Bulk sending HTTP alerts

### DIFF
--- a/src/events/CMakeLists.txt
+++ b/src/events/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library (events OBJECT
     event_queue.h
     sfeventq.cc
     sfeventq.h
+    http_queue.cc
+    http_queue.h
     ${INCLUDES}
 )
 

--- a/src/events/http_queue.cc
+++ b/src/events/http_queue.cc
@@ -1,0 +1,64 @@
+//--------------------------------------------------------------------------
+// Copyright (C) 2014-2024 Cisco and/or its affiliates. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License Version 2 as published
+// by the Free Software Foundation.  You may not use, modify or distribute
+// this program under any other version of the GNU General Public License.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//--------------------------------------------------------------------------
+
+#include "http_queue.h"
+
+AsyncResponseManager::AsyncResponseManager(std::chrono::milliseconds interval_)
+    : shutdown(false), interval(interval_), worker_thread(&AsyncResponseManager::worker, this) {}
+
+AsyncResponseManager::~AsyncResponseManager() {
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        shutdown = true;
+    }
+    cv.notify_one();
+    if (worker_thread.joinable()) {
+        worker_thread.join();
+    }
+}
+
+void AsyncResponseManager::worker() {
+    std::unique_lock<std::mutex> lock(mtx);
+    while (!shutdown) {
+        cv.wait_for(lock, interval);
+        std::vector<cpr::AsyncResponse> to_process;
+        to_process.swap(pending_responses);
+        lock.unlock();
+        for (auto& resp : to_process) {
+            resp.get();
+        }
+        lock.lock();
+    }
+    for (auto& resp : pending_responses) {
+        resp.get();
+    }
+    pending_responses.clear();
+}
+
+AsyncResponseManager& AsyncResponseManager::getInstance() {
+    static AsyncResponseManager instance;
+    return instance;
+}
+
+void AsyncResponseManager::addResponse(cpr::AsyncResponse&& response) {
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        pending_responses.push_back(std::move(response));
+    }
+    cv.notify_one();
+}

--- a/src/events/http_queue.h
+++ b/src/events/http_queue.h
@@ -1,0 +1,50 @@
+//--------------------------------------------------------------------------
+// Copyright (C) 2014-2024 Cisco and/or its affiliates. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License Version 2 as published
+// by the Free Software Foundation.  You may not use, modify or distribute
+// this program under any other version of the GNU General Public License.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//--------------------------------------------------------------------------
+
+#pragma once
+#include <vector>
+#include <mutex>
+#include <thread>
+#include <condition_variable>
+#include <chrono>
+#include <cpr/cpr.h>
+
+#define CLEAN_VECTOR_EVERY 60
+
+class AsyncResponseManager {
+private:
+    std::vector<cpr::AsyncResponse> pending_responses;
+    std::mutex mtx;
+    std::condition_variable cv;
+    bool shutdown;
+    std::thread worker_thread;
+    std::chrono::milliseconds interval;
+
+    AsyncResponseManager(std::chrono::milliseconds interval = std::chrono::seconds(CLEAN_VECTOR_EVERY));
+    ~AsyncResponseManager();
+
+    AsyncResponseManager(const AsyncResponseManager&) = delete;
+    AsyncResponseManager& operator=(const AsyncResponseManager&) = delete;
+
+    void worker();
+
+public:
+    static AsyncResponseManager& getInstance();
+
+    void addResponse(cpr::AsyncResponse&& response);
+};

--- a/src/file_api/file_capture.cc
+++ b/src/file_api/file_capture.cc
@@ -39,6 +39,7 @@
 #include "main/thread.h"
 #include "utils/stats.h"
 #include "utils/util.h"
+#include "events/http_queue.h"
 
 #include "file_mempool.h"
 #include "file_stats.h"
@@ -562,6 +563,7 @@ void FileCapture::store_file_s3()
         return;
 
     cpr::AsyncResponse async_response = s3_uploader->putObjectAsync(object_key, body, "application/octet-stream");
+    AsyncResponseManager::getInstance().addResponse(std::move(async_response));
 }
 
 // Queue files to be stored to disk

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -148,21 +148,17 @@ public:
         std::string current_host = events.front().host;
         std::cout << "[flushQueue] Starting flush for host: " << current_host << std::endl;
 
-        std::string batch_payload = "[";
-        bool first = true;
+        std::string batch_payload;
         size_t message_count = 0;
 
         while (!events.empty() && events.front().host == current_host) {
             std::cout << "[flushQueue] Adding message to batch: " << events.front().msg << std::endl;
 
-            if (!first) batch_payload += ",";
-            batch_payload += events.front().msg;
-            first = false;
+            batch_payload += events.front().msg + "\n";  // Add each JSON object followed by a newline
             events.pop();
             ++message_count;
         }
 
-        batch_payload += "]";
         std::cout << "[flushQueue] Constructed batch payload with " << message_count 
                 << " messages for host: " << current_host << std::endl;
         std::cout << "[flushQueue] Payload: " << batch_payload << std::endl;

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -77,106 +77,54 @@ struct QueueMsg {
     std::string host;
 };
 
+uint32_t global_max_queue_size = DEF_HTTP_MAX_QUEUE_SIZE;
+std::chrono::milliseconds global_max_time = std::chrono::seconds{DEF_HTTP_MAX_SECONDS};
+bool global_verify_ssl;
+
 class AlertQueue {
 private:
 
-    bool verify_ssl;
     std::queue<QueueMsg> events;
-    uint32_t max_queue_size = DEF_HTTP_MAX_QUEUE_SIZE;
-
-    std::chrono::milliseconds max_time = std::chrono::seconds{DEF_HTTP_MAX_SECONDS};
-
     std::chrono::steady_clock::time_point last_flush_time = std::chrono::steady_clock::now();
 
-    cpr::AsyncResponse buildAsyncReq(const std::string& host, const std::string& body, bool verify_ssl) {
+    cpr::AsyncResponse buildAsyncReq(const std::string& host, const std::string& body) {
         return cpr::PostAsync(
             cpr::Url{host},
             cpr::Body{body},
             cpr::Header{{"Content-Type", "application/json"}},
-            cpr::VerifySsl(verify_ssl)
+            cpr::VerifySsl(global_verify_ssl)
         );
     }
 
 public:
-    void setMaxQueueSize(uint32_t size) {
-        this->max_queue_size = size;
-    }
 
-    void setMaxTime(std::chrono::milliseconds time) {
-        this->max_time = time;
-    }
-
-    void setVerifySSL(bool verify_ssl){
-        this->verify_ssl = verify_ssl;
+    bool ShouldFlushFIFO(){
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_flush_time);
+        return events.size() >= global_max_queue_size || elapsed >= global_max_time;
     }
 
     void enqueue(const std::string& host, const std::string& msg) {
-        std::cout << "[enqueue] Received message for host: " << host << ", message: " << msg << std::endl;
-
-        std::cout << "[enqueue] max_queue_size: " << this->max_queue_size 
-                << ", max_time: " << this->max_time.count() << "ms" << std::endl;
-
         events.push({msg, host});
-        std::cout << "[enqueue] Queue size after push: " << events.size() << std::endl;
 
-        auto now = std::chrono::steady_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_flush_time);
-
-        std::cout << "[enqueue] Time since last flush: " << elapsed.count() << "ms" << std::endl;
-
-        std::cout << "[enqueue] Evaluating flush conditions..." << std::endl;
-        if (events.size() >= this->max_queue_size) {
-            std::cout << "[enqueue] Flush triggered due to queue size: " << events.size() 
-                    << " >= " << this->max_queue_size << std::endl;
-        }
-        if (elapsed >= this->max_time) {
-            std::cout << "[enqueue] Flush triggered due to timeout: " << elapsed.count() 
-                    << "ms >= " << this->max_time.count() << "ms" << std::endl;
-        }
-
-        if (events.size() >= this->max_queue_size || elapsed >= this->max_time) {
-            std::cout << "[enqueue] Flushing queue..." << std::endl;
+        if (this->ShouldFlushFIFO()) {
             flushQueue();
-            last_flush_time = std::chrono::steady_clock::now();
-            std::cout << "[enqueue] Flush complete. Reset last_flush_time." << std::endl;
-        } else {
-            std::cout << "[enqueue] Flush not required." << std::endl;
         }
     }
 
     void flushQueue() {
-        std::cout << "[flushQueue] Called." << std::endl;
-
-        if (events.empty()) {
-            std::cout << "[flushQueue] Queue is empty. Nothing to flush." << std::endl;
-            return;
-        }
-
         std::string current_host = events.front().host;
-        std::cout << "[flushQueue] Starting flush for host: " << current_host << std::endl;
-
         std::string batch_payload;
         size_t message_count = 0;
 
         while (!events.empty() && events.front().host == current_host) {
-            std::cout << "[flushQueue] Adding message to batch: " << events.front().msg << std::endl;
-
-            batch_payload += events.front().msg + "\n";  // Add each JSON object followed by a newline
+            batch_payload += events.front().msg + "\n";
             events.pop();
             ++message_count;
         }
-
-        std::cout << "[flushQueue] Constructed batch payload with " << message_count 
-                << " messages for host: " << current_host << std::endl;
-        std::cout << "[flushQueue] Payload: " << batch_payload << std::endl;
-
-        auto async_response = buildAsyncReq(current_host, batch_payload, verify_ssl);
-        std::cout << "[flushQueue] Async request built. Submitting to AsyncResponseManager." << std::endl;
-
+        auto async_response = buildAsyncReq(current_host, batch_payload);
         AsyncResponseManager::getInstance().addResponse(std::move(async_response));
-
         last_flush_time = std::chrono::steady_clock::now();
-        std::cout << "[flushQueue] Flush complete. Updated last_flush_time." << std::endl;
     }
 
 };
@@ -1076,7 +1024,6 @@ public:
 
 bool HTTPModule::set(const char *, Value &v, SnortConfig *)
 {
-    std::cout << v.is("bulk_queue_size") << std::endl;
     if (v.is("fields"))
     {
         string tok;
@@ -1114,25 +1061,21 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
         if (_mode == "bulk") {
             mode = MODE_BULK;
         }
-        std::cout << _mode << std::endl;
     }
     
     else if(v.is("bulk_queue_size")){
         uint32_t max_queue_size = v.get_uint32();
-        std::cout << "SIZE" << std::endl;
-        alert_queue.setMaxQueueSize(max_queue_size);
+        global_max_queue_size = max_queue_size;
     }
 
     else if(v.is("max_queue_flush_time")){
         uint32_t max_queue_flush_time = v.get_uint32();
-        alert_queue.setMaxTime(std::chrono::milliseconds{max_queue_flush_time});
+        global_max_time = std::chrono::milliseconds{max_queue_flush_time};
     }
 
-    std::cout << static_cast<int>(mode) << std::endl;
     if (mode != MODE_BULK && mode != MODE_NORMAL) {
         mode = MODE_NORMAL;
     }
-    std::cout << static_cast<int>(mode) << std::endl;
     return true;
 }
 
@@ -1194,7 +1137,7 @@ HTTPLogger::HTTPLogger(HTTPModule *m)
     verify_ssl = m->verify_ssl;
     http_endpoint = m->http_endpoint;
     mode = m->mode;
-    alert_queue.setVerifySSL(verify_ssl);
+    global_verify_ssl = verify_ssl;
 }
 
 void HTTPLogger::open()
@@ -1232,13 +1175,11 @@ void HTTPLogger::alert(Packet *p, const char *msg, const Event &event)
     BinaryWriter_Print(json_log, " }");
 
     char *json_event = BinaryWriter_FlushToString(json_log);
-    std::cout << "alert" << std::endl;
     if (json_event)
     {
         std::string json_copy(json_event);
         switch(mode){
             case MODE_NORMAL: {
-                std:cout << "MODE NORMAL" << std::endl;
                 auto async_response = cpr::PostAsync(
                     cpr::Url{http_endpoint},
                     cpr::Body{json_copy},
@@ -1249,7 +1190,6 @@ void HTTPLogger::alert(Packet *p, const char *msg, const Event &event)
                 break;
             }
             case MODE_BULK:
-                std::cout << "MODE BULK" << std::endl;
                 alert_queue.enqueue(http_endpoint, json_copy);
                 break;
         }

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -129,10 +129,17 @@ private:
         return batch_payload;
     }
 
+    bool is_time_reached(){
+        return timer_.elapsed() >= global_max_time;
+    }
+
+    bool is_full(){
+        return events_.size() >= global_max_queue_size;
+    }
 public:
     bool should_flush() const {
         if (events_.empty()) return false;
-        return events_.size() >= global_max_queue_size || timer_.elapsed() >= global_max_time;
+        return this->is_full() || this->is_time_reached();
     }
 
     bool is_empty() const {
@@ -140,6 +147,9 @@ public:
     }
 
     void enqueue(const std::string& host, const std::string& msg) {
+        if (this->is_full()) // We pop if queue full hehe (oldest discarded)
+            events_.pop();
+        
         events_.push(QueueMsg{msg, host});
 
         if (should_flush()) {

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -88,7 +88,7 @@ private:
     std::queue<QueueMsg> events;
     std::chrono::steady_clock::time_point last_flush_time = std::chrono::steady_clock::now();
 
-    cpr::AsyncResponse buildAsyncReq(const std::string& host, const std::string& body) {
+    cpr::AsyncResponse build_async_req(const std::string& host, const std::string& body) {
         return cpr::PostAsync(
             cpr::Url{host},
             cpr::Body{body},
@@ -99,25 +99,25 @@ private:
 
 public:
 
-    bool ShouldFlushFIFO(){
+    bool should_flush_fifo(){
         auto now = std::chrono::steady_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_flush_time);
         return events.size() >= global_max_queue_size || elapsed >= global_max_time;
     }
 
-    std::queue<QueueMsg> GetEvents(){
+    std::queue<QueueMsg> get_events(){
         return this->events;
     }
 
     void enqueue(const std::string& host, const std::string& msg) {
         events.push({msg, host});
 
-        if (this->ShouldFlushFIFO()) {
-            flushQueue();
+        if (this->should_flush_fifo()) {
+            flush_queue();
         }
     }
 
-    void flushQueue() {
+    void flush_queue() {
         std::string current_host = events.front().host;
         std::string batch_payload;
         size_t message_count = 0;
@@ -127,7 +127,7 @@ public:
             events.pop();
             ++message_count;
         }
-        auto async_response = buildAsyncReq(current_host, batch_payload);
+        auto async_response = build_async_req(current_host, batch_payload);
         AsyncResponseManager::getInstance().addResponse(std::move(async_response));
         last_flush_time = std::chrono::steady_clock::now();
     }
@@ -136,13 +136,13 @@ public:
 
 static void thread_flush_controller(std::atomic<bool>& running, AlertQueue& queue) {
     while (running) {
-        if (queue.ShouldFlushFIFO()) {
-            queue.flushQueue();
+        if (queue.should_flush_fifo()) {
+            queue.flush_queue();
         }
         std::this_thread::sleep_for(std::chrono::seconds(DEF_CONTROL_THREAD_SLEEP));
     }
-    while (!queue.GetEvents().empty()) {
-        queue.flushQueue();
+    while (!queue.get_events().empty()) {
+        queue.flush_queue();
     }
 }
 

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -121,12 +121,12 @@ private:
     Timer timer_;
 
     std::string build_payload(const std::string& current_host) {
-        std::string batch_payload;
+        std::ostringstream batch_payload;
         while (!events_.empty() && events_.front().host == current_host) {
-            batch_payload += events_.front().msg + "\n";
+            batch_payload << events_.front().msg << "\n";
             events_.pop();
         }
-        return batch_payload;
+        return batch_payload.str();
     }
 
     bool is_time_reached() const {
@@ -151,10 +151,6 @@ public:
             events_.pop();
         
         events_.push(QueueMsg{msg, host});
-
-        if (should_flush()) {
-            flush_queue();
-        }
     }
 
     void flush_queue() {
@@ -162,7 +158,7 @@ public:
             return;
         }
 
-        const std::string& current_host = events_.front().host;
+        std::string current_host = events_.front().host;
         std::string batch_payload = build_payload(current_host);
 
         if (!batch_payload.empty()) {
@@ -1257,6 +1253,8 @@ void HTTPLogger::alert(Packet *p, const char *msg, const Event &event)
             }
             case MODE::BULK:
                 alert_queue.enqueue(http_endpoint, json_copy);
+                if(alert_queue.should_flush())
+                    alert_queue.flush_queue();
                 break;
         }
         free(json_event);

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -76,11 +76,6 @@ MacVendorDatabase& HTTPMacVendorDB() {
     return *_HTTPMacVendorDB;
 }
 
-struct QueueMsg {
-    string msg;
-    string host;
-};
-
 uint32_t global_max_queue_size = DEF_HTTP_MAX_QUEUE_SIZE;
 chrono::milliseconds global_max_time = chrono::seconds{DEF_HTTP_MAX_SECONDS};
 bool global_verify_ssl;
@@ -96,8 +91,12 @@ namespace AlertHTTP {
     }
     class AlertQueue {
     private:
-
-        queue<QueueMsg> events;
+        struct QueueMsg {
+            string msg;
+            string host;
+        };
+        
+        queue<AlertHTTP::AlertQueue::QueueMsg> events;
         chrono::steady_clock::time_point last_flush_time = chrono::steady_clock::now();
 
         string build_payload(string current_host){
@@ -110,7 +109,6 @@ namespace AlertHTTP {
         }
 
     public:
-
         bool should_flush_fifo(){
             auto now = chrono::steady_clock::now();
             auto elapsed = chrono::duration_cast<chrono::milliseconds>(now - last_flush_time);
@@ -139,7 +137,6 @@ namespace AlertHTTP {
 
     };
 }
-
 
 static void thread_flush_controller(atomic<bool>& running, AlertHTTP::AlertQueue& queue) {
     while (running) {

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -1204,10 +1204,12 @@ void HTTPLogger::open()
 
     if(geoip_db.length() > 0) GeoIpLoader::Manager::getInstance(geoip_db);
     if(mac_vendors.length() > 0) HTTPMacVendorDB().insert_mac_vendors_from_file(mac_vendors.c_str());
-    fifo_flush_thread = true;
-    flush_thread.reset(new thread(thread_flush_controller, 
-                                     ref(fifo_flush_thread),
-                                     ref(alert_queue)));
+    if(mode == MODE::BULK){
+        fifo_flush_thread = true;
+        flush_thread.reset(new thread(thread_flush_controller, 
+                                        ref(fifo_flush_thread),
+                                        ref(alert_queue)));
+    }
 
 }
 
@@ -1221,9 +1223,11 @@ void HTTPLogger::close()
     }
     GeoIpLoader::Manager::getInstance()->unloadDB();
 
-    fifo_flush_thread = false;
-    if (flush_thread && flush_thread->joinable()) {
-        flush_thread->join();
+    if(mode == MODE::BULK){
+        fifo_flush_thread = false;
+        if (flush_thread && flush_thread->joinable()) {
+            flush_thread->join();
+        }
     }
 }
 

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -136,27 +136,46 @@ public:
             std::cout << "[enqueue] Flush not required." << std::endl;
         }
     }
-    
+
     void flushQueue() {
-        if (events.empty()) return;
+        std::cout << "[flushQueue] Called." << std::endl;
+
+        if (events.empty()) {
+            std::cout << "[flushQueue] Queue is empty. Nothing to flush." << std::endl;
+            return;
+        }
 
         std::string current_host = events.front().host;
-        std::string batch_payload = "[";
+        std::cout << "[flushQueue] Starting flush for host: " << current_host << std::endl;
 
+        std::string batch_payload = "[";
         bool first = true;
+        size_t message_count = 0;
+
         while (!events.empty() && events.front().host == current_host) {
+            std::cout << "[flushQueue] Adding message to batch: " << events.front().msg << std::endl;
+
             if (!first) batch_payload += ",";
             batch_payload += events.front().msg;
             first = false;
             events.pop();
+            ++message_count;
         }
+
         batch_payload += "]";
+        std::cout << "[flushQueue] Constructed batch payload with " << message_count 
+                << " messages for host: " << current_host << std::endl;
+        std::cout << "[flushQueue] Payload: " << batch_payload << std::endl;
 
         auto async_response = buildAsyncReq(current_host, batch_payload);
+        std::cout << "[flushQueue] Async request built. Submitting to AsyncResponseManager." << std::endl;
+
         AsyncResponseManager::getInstance().addResponse(std::move(async_response));
 
         last_flush_time = std::chrono::steady_clock::now();
+        std::cout << "[flushQueue] Flush complete. Updated last_flush_time." << std::endl;
     }
+
 };
 
 thread_local AlertQueue alert_queue;

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -55,8 +55,11 @@ using namespace std;
 
 #define LOG_BUFFER (4 * K_BYTES)
 
-#define MODE_BULK   0x01
-#define MODE_NORMAL 0x02
+enum MODE {
+    BULK,
+    NORMAL
+};
+
 #define DEF_HTTP_MAX_QUEUE_SIZE 1024
 #define DEF_HTTP_MAX_SECONDS 60
 #define DEF_CONTROL_THREAD_SLEEP 60
@@ -64,31 +67,26 @@ using namespace std;
 static THREAD_LOCAL BinaryWriter *json_log;
 static const char *priority_name[] = {NULL, "high", "medium", "low", "very low"};
 
-thread_local std::unique_ptr<MacVendorDatabase> _HTTPMacVendorDB = nullptr;
+thread_local unique_ptr<MacVendorDatabase> _HTTPMacVendorDB = nullptr;
 
 MacVendorDatabase& HTTPMacVendorDB() {
     if (!_HTTPMacVendorDB) {
-        _HTTPMacVendorDB = std::make_unique<MacVendorDatabase>();
+        _HTTPMacVendorDB = make_unique<MacVendorDatabase>();
     }
     return *_HTTPMacVendorDB;
 }
 
 struct QueueMsg {
-    std::string msg;
-    std::string host;
+    string msg;
+    string host;
 };
 
 uint32_t global_max_queue_size = DEF_HTTP_MAX_QUEUE_SIZE;
-std::chrono::milliseconds global_max_time = std::chrono::seconds{DEF_HTTP_MAX_SECONDS};
+chrono::milliseconds global_max_time = chrono::seconds{DEF_HTTP_MAX_SECONDS};
 bool global_verify_ssl;
 
-class AlertQueue {
-private:
-
-    std::queue<QueueMsg> events;
-    std::chrono::steady_clock::time_point last_flush_time = std::chrono::steady_clock::now();
-
-    cpr::AsyncResponse build_async_req(const std::string& host, const std::string& body) {
+namespace AlertHTTP {
+    static cpr::AsyncResponse build_async_req(const string& host, const string& body) {
         return cpr::PostAsync(
             cpr::Url{host},
             cpr::Body{body},
@@ -96,59 +94,68 @@ private:
             cpr::VerifySsl(global_verify_ssl)
         );
     }
+    class AlertQueue {
+    private:
 
-public:
+        queue<QueueMsg> events;
+        chrono::steady_clock::time_point last_flush_time = chrono::steady_clock::now();
 
-    bool should_flush_fifo(){
-        auto now = std::chrono::steady_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_flush_time);
-        return events.size() >= global_max_queue_size || elapsed >= global_max_time;
-    }
-
-    std::queue<QueueMsg> get_events(){
-        return this->events;
-    }
-
-    void enqueue(const std::string& host, const std::string& msg) {
-        events.push({msg, host});
-
-        if (this->should_flush_fifo()) {
-            flush_queue();
+        string build_payload(string current_host){
+            string batch_payload;
+            while (!events.empty() && events.front().host == current_host) {
+                batch_payload += events.front().msg + "\n";
+                events.pop();
+            }
+            return batch_payload;
         }
-    }
 
-    void flush_queue() {
-        std::string current_host = events.front().host;
-        std::string batch_payload;
-        size_t message_count = 0;
+    public:
 
-        while (!events.empty() && events.front().host == current_host) {
-            batch_payload += events.front().msg + "\n";
-            events.pop();
-            ++message_count;
+        bool should_flush_fifo(){
+            auto now = chrono::steady_clock::now();
+            auto elapsed = chrono::duration_cast<chrono::milliseconds>(now - last_flush_time);
+            return events.size() >= global_max_queue_size || elapsed >= global_max_time;
         }
-        auto async_response = build_async_req(current_host, batch_payload);
-        AsyncResponseManager::getInstance().addResponse(std::move(async_response));
-        last_flush_time = std::chrono::steady_clock::now();
-    }
 
-};
+        bool fifo_is_empty(){
+            return events.empty();
+        }
 
-static void thread_flush_controller(std::atomic<bool>& running, AlertQueue& queue) {
+        void enqueue(const string& host, const string& msg) {
+            events.push({msg, host});
+
+            if (this->should_flush_fifo()) {
+                flush_queue();
+            }
+        }
+
+        void flush_queue() {
+            string current_host = events.front().host;
+            string batch_payload = this->build_payload(current_host);
+            auto async_response = AlertHTTP::build_async_req(current_host, batch_payload);
+            AsyncResponseManager::getInstance().addResponse(move(async_response));
+            last_flush_time = chrono::steady_clock::now();
+        }
+
+    };
+}
+
+
+static void thread_flush_controller(atomic<bool>& running, AlertHTTP::AlertQueue& queue) {
     while (running) {
         if (queue.should_flush_fifo()) {
             queue.flush_queue();
         }
-        std::this_thread::sleep_for(std::chrono::seconds(DEF_CONTROL_THREAD_SLEEP));
+        this_thread::sleep_for(chrono::seconds(DEF_CONTROL_THREAD_SLEEP));
     }
-    while (!queue.get_events().empty()) {
+    while (!queue.fifo_is_empty()) {
         queue.flush_queue();
     }
 }
 
-thread_local AlertQueue alert_queue;
-thread_local std::unique_ptr<std::thread> flush_thread;
-thread_local std::atomic<bool> fifo_flush_thread{false};
+thread_local AlertHTTP::AlertQueue alert_queue;
+thread_local unique_ptr<thread> flush_thread;
+thread_local atomic<bool> fifo_flush_thread{false};
 
 #define S_NAME "alert_http"
 
@@ -1078,7 +1085,7 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
     else if (v.is("mode")){
         string _mode = v.get_string();
         if (_mode == "bulk") {
-            mode = MODE_BULK;
+            mode = MODE::BULK;
         }
     }
     
@@ -1089,11 +1096,11 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
 
     else if(v.is("max_queue_flush_time")){
         uint32_t max_queue_flush_time = v.get_uint32();
-        global_max_time = std::chrono::milliseconds{max_queue_flush_time};
+        global_max_time = chrono::milliseconds{max_queue_flush_time};
     }
 
-    if (mode != MODE_BULK && mode != MODE_NORMAL) {
-        mode = MODE_NORMAL;
+    if (mode != MODE::BULK && mode != MODE::NORMAL) {
+        mode = MODE::NORMAL;
     }
     return true;
 }
@@ -1140,7 +1147,7 @@ private:
     string geoip_db;
     vector<JsonFunc> fields;
     string enrichment;
-    std::string http_endpoint;
+    string http_endpoint;
     bool verify_ssl;
     char errstr[512];
 };
@@ -1166,9 +1173,9 @@ void HTTPLogger::open()
     if(geoip_db.length() > 0) GeoIpLoader::Manager::getInstance(geoip_db);
     if(mac_vendors.length() > 0) HTTPMacVendorDB().insert_mac_vendors_from_file(mac_vendors.c_str());
     fifo_flush_thread = true;
-    flush_thread.reset(new std::thread(thread_flush_controller, 
-                                     std::ref(fifo_flush_thread),
-                                     std::ref(alert_queue)));
+    flush_thread.reset(new thread(thread_flush_controller, 
+                                     ref(fifo_flush_thread),
+                                     ref(alert_queue)));
 
 }
 
@@ -1205,19 +1212,14 @@ void HTTPLogger::alert(Packet *p, const char *msg, const Event &event)
     char *json_event = BinaryWriter_FlushToString(json_log);
     if (json_event)
     {
-        std::string json_copy(json_event);
+        string json_copy(json_event);
         switch(mode){
-            case MODE_NORMAL: {
-                auto async_response = cpr::PostAsync(
-                    cpr::Url{http_endpoint},
-                    cpr::Body{json_copy},
-                    cpr::Header{{"Content-Type", "application/json"}},
-                    cpr::VerifySsl(verify_ssl)
-                );
-                AsyncResponseManager::getInstance().addResponse(std::move(async_response));
+            case MODE::NORMAL: {
+                cpr::AsyncResponse async_response = AlertHTTP::build_async_req(http_endpoint, json_copy);
+                AsyncResponseManager::getInstance().addResponse(move(async_response));
                 break;
             }
-            case MODE_BULK:
+            case MODE::BULK:
                 alert_queue.enqueue(http_endpoint, json_copy);
                 break;
         }

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -1076,6 +1076,7 @@ public:
 
 bool HTTPModule::set(const char *, Value &v, SnortConfig *)
 {
+    std::cout << v.is("bulk_queue_size") << std::endl;
     if (v.is("fields"))
     {
         string tok;
@@ -1115,6 +1116,7 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
         }
         std::cout << _mode << std::endl;
     }
+    
     else if(v.is("bulk_queue_size")){
         uint32_t max_queue_size = v.get_uint32();
         std::cout << "SIZE" << std::endl;

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -1080,8 +1080,11 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
         alert_queue.setMaxTime(std::chrono::milliseconds{max_queue_flush_time});
     }
 
-    if(mode != MODE_BULK || mode != MODE_NORMAL) mode = MODE_NORMAL;
-
+    std::cout << static_cast<int>(mode) << std::endl;
+    if (mode != MODE_BULK && mode != MODE_NORMAL) {
+        mode = MODE_NORMAL;
+    }
+    std::cout << static_cast<int>(mode) << std::endl;
     return true;
 }
 
@@ -1185,6 +1188,7 @@ void HTTPLogger::alert(Packet *p, const char *msg, const Event &event)
         std::string json_copy(json_event);
         switch(mode){
             case MODE_NORMAL: {
+                std:cout << "MODE NORMAL" << std::endl;
                 auto async_response = cpr::PostAsync(
                     cpr::Url{http_endpoint},
                     cpr::Body{json_copy},
@@ -1195,6 +1199,7 @@ void HTTPLogger::alert(Packet *p, const char *msg, const Event &event)
                 break;
             }
             case MODE_BULK:
+                std::cout << "MODE BULK" << std::endl;
                 alert_queue.enqueue(http_endpoint, json_copy);
                 break;
         }

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -1074,11 +1074,11 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
 
     else if(v.is("max_queue_flush_time")){
         uint32_t max_queue_flush_time = v.get_uint32();
-        alert_queue.setMaxQueueSize(max_queue_flush_time);
+        alert_queue.setMaxTime(max_queue_flush_time);
     }
 
     if(mode != MODE_BULK || mode != MODE_NORMAL) mode = MODE_NORMAL;
-    
+
     return true;
 }
 

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -1074,7 +1074,7 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
 
     else if(v.is("max_queue_flush_time")){
         uint32_t max_queue_flush_time = v.get_uint32();
-        alert_queue.setMaxTime(max_queue_flush_time);
+        alert_queue.setMaxTime(std::chrono::milliseconds{max_queue_flush_time});
     }
 
     if(mode != MODE_BULK || mode != MODE_NORMAL) mode = MODE_NORMAL;

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -147,7 +147,7 @@ public:
     }
 
     void enqueue(const std::string& host, const std::string& msg) {
-        if (this->is_full()) // We pop if queue full hehe (oldest discarded)
+        if (this->is_full()) // We pop if queue full (oldest discarded)
             events_.pop();
         
         events_.push(QueueMsg{msg, host});
@@ -163,7 +163,7 @@ public:
 
         if (!batch_payload.empty()) {
             auto async_response = build_async_req(current_host, batch_payload);
-            // For the cool dev (The panic dev) -> we want best effort sending, we dont need to handle errors
+            // We want best effort sending, we dont need to handle errors
             // re-sending alerts or something related, if we lose the req, then we dont do anyhing
             AsyncResponseManager::getInstance().addResponse(std::move(async_response));
             timer_.reset();

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -45,6 +45,7 @@
 #include "protocols/udp.h"
 #include "protocols/vlan.h"
 #include "utils/stats.h"
+#include "events/http_queue.h"
 #include "enrichment/sensor_enrichment.h"
 
 #define DEF_VERIFY_SSL "true"
@@ -53,6 +54,11 @@ using namespace snort;
 using namespace std;
 
 #define LOG_BUFFER (4 * K_BYTES)
+
+#define MODE_BULK   0x01
+#define MODE_NORMAL 0x02
+#define DEF_HTTP_MAX_QUEUE_SIZE 1024
+#define DEF_HTTP_MAX_SECONDS 60000
 
 static THREAD_LOCAL BinaryWriter *json_log;
 static const char *priority_name[] = {NULL, "high", "medium", "low", "very low"};
@@ -65,6 +71,73 @@ MacVendorDatabase& HTTPMacVendorDB() {
     }
     return *_HTTPMacVendorDB;
 }
+
+struct QueueMsg {
+    std::string msg;
+    std::string host;
+};
+
+class AlertQueue {
+private:
+    std::queue<QueueMsg> events;
+    size_t max_queue_size = DEF_HTTP_MAX_QUEUE_SIZE;
+
+    std::chrono::milliseconds max_time = std::chrono::seconds{DEF_HTTP_MAX_SECONDS};
+
+    std::chrono::steady_clock::time_point last_flush_time = std::chrono::steady_clock::now();
+
+    cpr::AsyncResponse buildAsyncReq(const std::string& host, const std::string& body) {
+        return cpr::PostAsync(
+            cpr::Url{host},
+            cpr::Body{body},
+            cpr::Header{{"Content-Type", "application/json"}}
+        );
+    }
+
+public:
+    void setMaxQueueSize(size_t size) {
+        max_queue_size = size;
+    }
+
+    void setMaxTime(std::chrono::milliseconds time) {
+        max_time = time;
+    }
+
+    void enqueue(const std::string& host, const std::string& msg) {
+        events.push({msg, host});
+
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_flush_time);
+
+        if (events.size() >= max_queue_size || elapsed >= max_time) {
+            flushQueue();
+            last_flush_time = std::chrono::steady_clock::now();
+        }
+    }
+
+    void flushQueue() {
+        if (events.empty()) return;
+
+        std::string current_host = events.front().host;
+        std::string batch_payload = "[";
+
+        bool first = true;
+        while (!events.empty() && events.front().host == current_host) {
+            if (!first) batch_payload += ",";
+            batch_payload += events.front().msg;
+            first = false;
+            events.pop();
+        }
+        batch_payload += "]";
+
+        auto async_response = buildAsyncReq(current_host, batch_payload);
+        AsyncResponseManager::getInstance().addResponse(std::move(async_response));
+
+        last_flush_time = std::chrono::steady_clock::now();
+    }
+};
+
+thread_local AlertQueue alert_queue;
 
 #define S_NAME "alert_http"
 
@@ -912,6 +985,15 @@ static const Parameter s_params[] =
 
         {"geoip_db", Parameter::PT_STRING, nullptr, nullptr,
          "geoip database"},
+    
+        {"mode", Parameter::PT_STRING, nullptr, nullptr,
+         "mode"},
+
+        {"bulk_queue_size", Parameter::PT_INT, nullptr, nullptr,
+        "bulk_queue_size"},
+
+        {"max_queue_flush_time", Parameter::PT_INT, nullptr, nullptr,
+        "max_queue_flush_time"},
 
         {"fields", Parameter::PT_MULTI, json_range, json_deflt,
          "selected fields will be output in given order left to right"},
@@ -939,6 +1021,7 @@ public:
 
 public:
     string sep;
+    uint8_t mode;
     string http_endpoint;
     string enrichment;
     string mac_vendors;
@@ -977,6 +1060,25 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
     else if (v.is("geoip_db"))
         geoip_db = v.get_string();
 
+    else if (v.is("mode")){
+        string _mode = v.get_string();
+        if (_mode == "bulk") {
+            mode = MODE_BULK;
+        }
+    }
+
+    else if(v.is("bulk_queue_size")){
+        uint32_t max_queue_size = v.get_uint32();
+        alert_queue.setMaxQueueSize(max_queue_size);
+    }
+
+    else if(v.is("max_queue_flush_time")){
+        uint32_t max_queue_flush_time = v.get_uint32();
+        alert_queue.setMaxQueueSize(max_queue_flush_time);
+    }
+
+    if(mode != MODE_BULK || mode != MODE_NORMAL) mode = MODE_NORMAL;
+    
     return true;
 }
 
@@ -1015,6 +1117,7 @@ public:
     void alert(Packet *p, const char *msg, const Event &event) override;
 
 private:
+    uint8_t mode;
     string sep;
     string group_name;
     string mac_vendors;
@@ -1035,6 +1138,7 @@ HTTPLogger::HTTPLogger(HTTPModule *m)
     mac_vendors = m->mac_vendors;
     geoip_db = m->geoip_db;
     http_endpoint = m->http_endpoint;
+    mode = m->mode;
 }
 
 void HTTPLogger::open()
@@ -1074,17 +1178,25 @@ void HTTPLogger::alert(Packet *p, const char *msg, const Event &event)
     char *json_event = BinaryWriter_FlushToString(json_log);
     if (json_event)
     {
-        size_t json_event_size = strlen(json_event);
-
-        cpr::AsyncResponse response = cpr::PostAsync(
-            cpr::Url{http_endpoint},
-            cpr::Body{json_event},
-            cpr::Header{{"Content-Type", "application/json"}},
-            cpr::VerifySsl(verify_ssl)
-        );
-
+        std::string json_copy(json_event);
+        switch(mode){
+            case MODE_NORMAL: {
+                auto async_response = cpr::PostAsync(
+                    cpr::Url{http_endpoint},
+                    cpr::Body{json_copy},
+                    cpr::Header{{"Content-Type", "application/json"}},
+                    cpr::VerifySsl(verify_ssl)
+                );
+                AsyncResponseManager::getInstance().addResponse(std::move(async_response));
+                break;
+            }
+            case MODE_BULK:
+                alert_queue.enqueue(http_endpoint, json_copy);
+                break;
+        }
         free(json_event);
     }
+
 }   
 
 //-------------------------------------------------------------------------

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -79,6 +79,8 @@ struct QueueMsg {
 
 class AlertQueue {
 private:
+
+    bool verify_ssl;
     std::queue<QueueMsg> events;
     size_t max_queue_size = DEF_HTTP_MAX_QUEUE_SIZE;
 
@@ -86,11 +88,12 @@ private:
 
     std::chrono::steady_clock::time_point last_flush_time = std::chrono::steady_clock::now();
 
-    cpr::AsyncResponse buildAsyncReq(const std::string& host, const std::string& body) {
+    cpr::AsyncResponse buildAsyncReq(const std::string& host, const std::string& body, bool verify_ssl) {
         return cpr::PostAsync(
             cpr::Url{host},
             cpr::Body{body},
-            cpr::Header{{"Content-Type", "application/json"}}
+            cpr::Header{{"Content-Type", "application/json"}},
+            cpr::VerifySsl(verify_ssl)
         );
     }
 
@@ -101,6 +104,10 @@ public:
 
     void setMaxTime(std::chrono::milliseconds time) {
         max_time = time;
+    }
+
+    void setVerifySSL(bool verify_ssl){
+        verify_ssl = verify_ssl;
     }
 
     void enqueue(const std::string& host, const std::string& msg) {
@@ -163,7 +170,7 @@ public:
                 << " messages for host: " << current_host << std::endl;
         std::cout << "[flushQueue] Payload: " << batch_payload << std::endl;
 
-        auto async_response = buildAsyncReq(current_host, batch_payload);
+        auto async_response = buildAsyncReq(current_host, batch_payload, verify_ssl);
         std::cout << "[flushQueue] Async request built. Submitting to AsyncResponseManager." << std::endl;
 
         AsyncResponseManager::getInstance().addResponse(std::move(async_response));
@@ -1063,6 +1070,7 @@ public:
     string enrichment;
     string mac_vendors;
     string geoip_db;
+    bool verify_ssl;
     vector<JsonFunc> fields;
 };
 
@@ -1096,7 +1104,10 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
 
     else if (v.is("geoip_db"))
         geoip_db = v.get_string();
-
+    
+    else if (v.is("verify_ssl"))
+        verify_ssl = v.get_bool();
+        
     else if (v.is("mode")){
         string _mode = v.get_string();
         if (_mode == "bulk") {
@@ -1178,8 +1189,10 @@ HTTPLogger::HTTPLogger(HTTPModule *m)
     fields.push_back(AddTimestampField);
     mac_vendors = m->mac_vendors;
     geoip_db = m->geoip_db;
+    verify_ssl = m->verify_ssl;
     http_endpoint = m->http_endpoint;
     mode = m->mode;
+    alert_queue.setVerifySSL(verify_ssl);
 }
 
 void HTTPLogger::open()

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -154,6 +154,8 @@ public:
 
         if (!batch_payload.empty()) {
             auto async_response = build_async_req(current_host, batch_payload);
+            // For the cool dev (The panic dev) -> we want best effort sending, we dont need to handle errors
+            // re-sending alerts or something related, if we lose the req, then we dont do anyhing
             AsyncResponseManager::getInstance().addResponse(std::move(async_response));
             timer_.reset();
         }

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -99,22 +99,22 @@ private:
 
 public:
     void setMaxQueueSize(uint32_t size) {
-        max_queue_size = size;
+        this->max_queue_size = size;
     }
 
     void setMaxTime(std::chrono::milliseconds time) {
-        max_time = time;
+        this->max_time = time;
     }
 
     void setVerifySSL(bool verify_ssl){
-        verify_ssl = verify_ssl;
+        this->verify_ssl = verify_ssl;
     }
 
     void enqueue(const std::string& host, const std::string& msg) {
         std::cout << "[enqueue] Received message for host: " << host << ", message: " << msg << std::endl;
 
-        std::cout << "[enqueue] max_queue_size: " << max_queue_size 
-                << ", max_time: " << max_time.count() << "ms" << std::endl;
+        std::cout << "[enqueue] max_queue_size: " << this->max_queue_size 
+                << ", max_time: " << this->max_time.count() << "ms" << std::endl;
 
         events.push({msg, host});
         std::cout << "[enqueue] Queue size after push: " << events.size() << std::endl;
@@ -125,16 +125,16 @@ public:
         std::cout << "[enqueue] Time since last flush: " << elapsed.count() << "ms" << std::endl;
 
         std::cout << "[enqueue] Evaluating flush conditions..." << std::endl;
-        if (events.size() >= max_queue_size) {
+        if (events.size() >= this->max_queue_size) {
             std::cout << "[enqueue] Flush triggered due to queue size: " << events.size() 
-                    << " >= " << max_queue_size << std::endl;
+                    << " >= " << this->max_queue_size << std::endl;
         }
-        if (elapsed >= max_time) {
+        if (elapsed >= this->max_time) {
             std::cout << "[enqueue] Flush triggered due to timeout: " << elapsed.count() 
-                    << "ms >= " << max_time.count() << "ms" << std::endl;
+                    << "ms >= " << this->max_time.count() << "ms" << std::endl;
         }
 
-        if (events.size() >= max_queue_size || elapsed >= max_time) {
+        if (events.size() >= this->max_queue_size || elapsed >= this->max_time) {
             std::cout << "[enqueue] Flushing queue..." << std::endl;
             flushQueue();
             last_flush_time = std::chrono::steady_clock::now();

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -129,11 +129,11 @@ private:
         return batch_payload;
     }
 
-    bool is_time_reached(){
+    bool is_time_reached() const {
         return timer_.elapsed() >= global_max_time;
     }
 
-    bool is_full(){
+    bool is_full() const {
         return events_.size() >= global_max_queue_size;
     }
 public:

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -82,7 +82,7 @@ private:
 
     bool verify_ssl;
     std::queue<QueueMsg> events;
-    size_t max_queue_size = DEF_HTTP_MAX_QUEUE_SIZE;
+    uint32_t max_queue_size = DEF_HTTP_MAX_QUEUE_SIZE;
 
     std::chrono::milliseconds max_time = std::chrono::seconds{DEF_HTTP_MAX_SECONDS};
 
@@ -98,8 +98,7 @@ private:
     }
 
 public:
-    void setMaxQueueSize(size_t size) {
-        std::cout << "call -> setMaxQueueSize" << std::endl;
+    void setMaxQueueSize(uint32_t size) {
         max_queue_size = size;
     }
 
@@ -1034,8 +1033,8 @@ static const Parameter s_params[] =
         {"mode", Parameter::PT_STRING, nullptr, nullptr,
          "mode"},
 
-        {"bulk_queue_size", Parameter::PT_INT, nullptr, nullptr,
-        "bulk_queue_size"},
+        {"bulk_queue_size", Parameter::PT_INT, "0:max32", nullptr,
+        "maximum number of events in queue before flushing"},
 
         {"max_queue_flush_time", Parameter::PT_INT, nullptr, nullptr,
         "max_queue_flush_time"},
@@ -1117,9 +1116,8 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
         std::cout << _mode << std::endl;
     }
     else if(v.is("bulk_queue_size")){
-        size_t max_queue_size = v.get_size();
+        uint32_t max_queue_size = v.get_uint32();
         std::cout << "SIZE" << std::endl;
-        std::cout << static_cast<int>(max_queue_size) << std::endl;
         alert_queue.setMaxQueueSize(max_queue_size);
     }
 

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -81,71 +81,95 @@ chrono::milliseconds global_max_time = chrono::seconds{DEF_HTTP_MAX_SECONDS};
 bool global_verify_ssl;
 
 namespace AlertHTTP {
-    static cpr::AsyncResponse build_async_req(const string& host, const string& body) {
-        return cpr::PostAsync(
-            cpr::Url{host},
-            cpr::Body{body},
-            cpr::Header{{"Content-Type", "application/json"}},
-            cpr::VerifySsl(global_verify_ssl)
-        );
+
+class Timer {
+private:
+    std::chrono::steady_clock::time_point last_time_;
+public:
+    Timer() : last_time_(std::chrono::steady_clock::now()) {}
+
+    void reset() {
+        last_time_ = std::chrono::steady_clock::now();
     }
-    class AlertQueue {
-    private:
-        struct QueueMsg {
-            string msg;
-            string host;
-        };
-        
-        queue<AlertHTTP::AlertQueue::QueueMsg> events;
-        chrono::steady_clock::time_point last_flush_time = chrono::steady_clock::now();
 
-        string build_payload(string current_host){
-            string batch_payload;
-            while (!events.empty() && events.front().host == current_host) {
-                batch_payload += events.front().msg + "\n";
-                events.pop();
-            }
-            return batch_payload;
-        }
+    std::chrono::milliseconds elapsed() const {
+        auto now = std::chrono::steady_clock::now();
+        return std::chrono::duration_cast<std::chrono::milliseconds>(now - last_time_);
+    }
+};
 
-    public:
-        bool should_flush_fifo(){
-            auto now = chrono::steady_clock::now();
-            auto elapsed = chrono::duration_cast<chrono::milliseconds>(now - last_flush_time);
-            return events.size() >= global_max_queue_size || elapsed >= global_max_time;
-        }
+static cpr::AsyncResponse build_async_req(const std::string& host, const std::string& body) {
+    return cpr::PostAsync(
+        cpr::Url{host},
+        cpr::Body{body},
+        cpr::Header{{"Content-Type", "application/json"}},
+        cpr::VerifySsl(global_verify_ssl)
+    );
+}
 
-        bool fifo_is_empty(){
-            return events.empty();
-        }
-
-        void enqueue(const string& host, const string& msg) {
-            events.push({msg, host});
-
-            if (this->should_flush_fifo()) {
-                flush_queue();
-            }
-        }
-
-        void flush_queue() {
-            string current_host = events.front().host;
-            string batch_payload = this->build_payload(current_host);
-            auto async_response = AlertHTTP::build_async_req(current_host, batch_payload);
-            AsyncResponseManager::getInstance().addResponse(move(async_response));
-            last_flush_time = chrono::steady_clock::now();
-        }
-
+class AlertQueue {
+private:
+    struct QueueMsg {
+        std::string msg;
+        std::string host;
     };
+
+    std::queue<QueueMsg> events_;
+    Timer timer_;
+
+    std::string build_payload(const std::string& current_host) {
+        std::string batch_payload;
+        while (!events_.empty() && events_.front().host == current_host) {
+            batch_payload += events_.front().msg + "\n";
+            events_.pop();
+        }
+        return batch_payload;
+    }
+
+public:
+    bool should_flush() const {
+        if (events_.empty()) return false;
+        return events_.size() >= global_max_queue_size || timer_.elapsed() >= global_max_time;
+    }
+
+    bool is_empty() const {
+        return events_.empty();
+    }
+
+    void enqueue(const std::string& host, const std::string& msg) {
+        events_.push(QueueMsg{msg, host});
+
+        if (should_flush()) {
+            flush_queue();
+        }
+    }
+
+    void flush_queue() {
+        if (events_.empty()) {
+            return;
+        }
+
+        const std::string& current_host = events_.front().host;
+        std::string batch_payload = build_payload(current_host);
+
+        if (!batch_payload.empty()) {
+            auto async_response = build_async_req(current_host, batch_payload);
+            AsyncResponseManager::getInstance().addResponse(std::move(async_response));
+            timer_.reset();
+        }
+    }
+};
+
 }
 
 static void thread_flush_controller(atomic<bool>& running, AlertHTTP::AlertQueue& queue) {
     while (running) {
-        if (queue.should_flush_fifo()) {
+        if (queue.should_flush()) {
             queue.flush_queue();
         }
         this_thread::sleep_for(chrono::seconds(DEF_CONTROL_THREAD_SLEEP));
     }
-    while (!queue.fifo_is_empty()) {
+    while (!queue.is_empty()) {
         queue.flush_queue();
     }
 }

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -148,7 +148,7 @@ static void thread_flush_controller(std::atomic<bool>& running, AlertQueue& queu
 
 thread_local AlertQueue alert_queue;
 thread_local std::unique_ptr<std::thread> flush_thread;
-thread_local std::atomic<bool> thread_running{false};
+thread_local std::atomic<bool> fifo_flush_thread{false};
 
 #define S_NAME "alert_http"
 
@@ -1165,9 +1165,9 @@ void HTTPLogger::open()
 
     if(geoip_db.length() > 0) GeoIpLoader::Manager::getInstance(geoip_db);
     if(mac_vendors.length() > 0) HTTPMacVendorDB().insert_mac_vendors_from_file(mac_vendors.c_str());
-    thread_running = true;
+    fifo_flush_thread = true;
     flush_thread.reset(new std::thread(thread_flush_controller, 
-                                     std::ref(thread_running),
+                                     std::ref(fifo_flush_thread),
                                      std::ref(alert_queue)));
 
 }
@@ -1182,7 +1182,7 @@ void HTTPLogger::close()
     }
     GeoIpLoader::Manager::getInstance()->unloadDB();
 
-    thread_running = false;
+    fifo_flush_thread = false;
     if (flush_thread && flush_thread->joinable()) {
         flush_thread->join();
     }

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -107,6 +107,9 @@ static cpr::AsyncResponse build_async_req(const std::string& host, const std::st
     );
 }
 
+// no mutex needed, each thread has his own copy
+// of the the queue (-z num_thread) so we are
+// sure each thread has his own queue & control thread
 class AlertQueue {
 private:
     struct QueueMsg {

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -58,7 +58,7 @@ using namespace std;
 #define MODE_BULK   0x01
 #define MODE_NORMAL 0x02
 #define DEF_HTTP_MAX_QUEUE_SIZE 1024
-#define DEF_HTTP_MAX_SECONDS 60000
+#define DEF_HTTP_MAX_SECONDS 60
 
 static THREAD_LOCAL BinaryWriter *json_log;
 static const char *priority_name[] = {NULL, "high", "medium", "low", "very low"};
@@ -104,19 +104,39 @@ public:
     }
 
     void enqueue(const std::string& host, const std::string& msg) {
-        std::cout << "enqueue" << std::endl;
+        std::cout << "[enqueue] Received message for host: " << host << ", message: " << msg << std::endl;
+
+        std::cout << "[enqueue] max_queue_size: " << max_queue_size 
+                << ", max_time: " << max_time.count() << "ms" << std::endl;
+
         events.push({msg, host});
+        std::cout << "[enqueue] Queue size after push: " << events.size() << std::endl;
 
         auto now = std::chrono::steady_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_flush_time);
 
+        std::cout << "[enqueue] Time since last flush: " << elapsed.count() << "ms" << std::endl;
+
+        std::cout << "[enqueue] Evaluating flush conditions..." << std::endl;
+        if (events.size() >= max_queue_size) {
+            std::cout << "[enqueue] Flush triggered due to queue size: " << events.size() 
+                    << " >= " << max_queue_size << std::endl;
+        }
+        if (elapsed >= max_time) {
+            std::cout << "[enqueue] Flush triggered due to timeout: " << elapsed.count() 
+                    << "ms >= " << max_time.count() << "ms" << std::endl;
+        }
+
         if (events.size() >= max_queue_size || elapsed >= max_time) {
-            std::cout << "flush queue" << std::endl;
+            std::cout << "[enqueue] Flushing queue..." << std::endl;
             flushQueue();
             last_flush_time = std::chrono::steady_clock::now();
+            std::cout << "[enqueue] Flush complete. Reset last_flush_time." << std::endl;
+        } else {
+            std::cout << "[enqueue] Flush not required." << std::endl;
         }
     }
-
+    
     void flushQueue() {
         if (events.empty()) return;
 

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -59,6 +59,7 @@ using namespace std;
 #define MODE_NORMAL 0x02
 #define DEF_HTTP_MAX_QUEUE_SIZE 1024
 #define DEF_HTTP_MAX_SECONDS 60
+#define DEF_CONTROL_THREAD_SLEEP 60
 
 static THREAD_LOCAL BinaryWriter *json_log;
 static const char *priority_name[] = {NULL, "high", "medium", "low", "very low"};
@@ -104,6 +105,10 @@ public:
         return events.size() >= global_max_queue_size || elapsed >= global_max_time;
     }
 
+    std::queue<QueueMsg> GetEvents(){
+        return this->events;
+    }
+
     void enqueue(const std::string& host, const std::string& msg) {
         events.push({msg, host});
 
@@ -129,7 +134,21 @@ public:
 
 };
 
+static void thread_flush_controller(std::atomic<bool>& running, AlertQueue& queue) {
+    while (running) {
+        if (queue.ShouldFlushFIFO()) {
+            queue.flushQueue();
+        }
+        std::this_thread::sleep_for(std::chrono::seconds(DEF_CONTROL_THREAD_SLEEP));
+    }
+    while (!queue.GetEvents().empty()) {
+        queue.flushQueue();
+    }
+}
+
 thread_local AlertQueue alert_queue;
+thread_local std::unique_ptr<std::thread> flush_thread;
+thread_local std::atomic<bool> thread_running{false};
 
 #define S_NAME "alert_http"
 
@@ -1146,6 +1165,10 @@ void HTTPLogger::open()
 
     if(geoip_db.length() > 0) GeoIpLoader::Manager::getInstance(geoip_db);
     if(mac_vendors.length() > 0) HTTPMacVendorDB().insert_mac_vendors_from_file(mac_vendors.c_str());
+    thread_running = true;
+    flush_thread.reset(new std::thread(thread_flush_controller, 
+                                     std::ref(thread_running),
+                                     std::ref(alert_queue)));
 
 }
 
@@ -1158,6 +1181,11 @@ void HTTPLogger::close()
         _HTTPMacVendorDB.reset();
     }
     GeoIpLoader::Manager::getInstance()->unloadDB();
+
+    thread_running = false;
+    if (flush_thread && flush_thread->joinable()) {
+        flush_thread->join();
+    }
 }
 
 void HTTPLogger::alert(Packet *p, const char *msg, const Event &event)

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -104,12 +104,14 @@ public:
     }
 
     void enqueue(const std::string& host, const std::string& msg) {
+        std::cout << "enqueue" << std::endl;
         events.push({msg, host});
 
         auto now = std::chrono::steady_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_flush_time);
 
         if (events.size() >= max_queue_size || elapsed >= max_time) {
+            std::cout << "flush queue" << std::endl;
             flushQueue();
             last_flush_time = std::chrono::steady_clock::now();
         }
@@ -1065,6 +1067,7 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
         if (_mode == "bulk") {
             mode = MODE_BULK;
         }
+        std::cout << _mode << std::endl;
     }
 
     else if(v.is("bulk_queue_size")){
@@ -1176,6 +1179,7 @@ void HTTPLogger::alert(Packet *p, const char *msg, const Event &event)
     BinaryWriter_Print(json_log, " }");
 
     char *json_event = BinaryWriter_FlushToString(json_log);
+    std::cout << "alert" << std::endl;
     if (json_event)
     {
         std::string json_copy(json_event);

--- a/src/loggers/alert_http.cc
+++ b/src/loggers/alert_http.cc
@@ -99,6 +99,7 @@ private:
 
 public:
     void setMaxQueueSize(size_t size) {
+        std::cout << "call -> setMaxQueueSize" << std::endl;
         max_queue_size = size;
     }
 
@@ -1107,7 +1108,7 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
     
     else if (v.is("verify_ssl"))
         verify_ssl = v.get_bool();
-        
+
     else if (v.is("mode")){
         string _mode = v.get_string();
         if (_mode == "bulk") {
@@ -1115,9 +1116,10 @@ bool HTTPModule::set(const char *, Value &v, SnortConfig *)
         }
         std::cout << _mode << std::endl;
     }
-
     else if(v.is("bulk_queue_size")){
-        uint32_t max_queue_size = v.get_uint32();
+        size_t max_queue_size = v.get_size();
+        std::cout << "SIZE" << std::endl;
+        std::cout << static_cast<int>(max_queue_size) << std::endl;
         alert_queue.setMaxQueueSize(max_queue_size);
     }
 


### PR DESCRIPTION
* Implemented a FIFO queue to store HTTP messages and send them in bulk to the manager.
* Sending is triggered based on event-driven thresholds: time elapsed and queue size.
* Added a control thread to monitor and manage these time and queue size thresholds.
* Added thread to control async responses from CPR and prevents memory leaks 
